### PR TITLE
Add Chinese and German site languages

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -129,3 +129,49 @@ languages:
         - name: nostr
           weight: 5
           url: https://nostr.yusuke.cloud/junkpiano@yusuke.cloud
+  zh:
+    LanguageName: ':cn:'
+    contentDir: content/chinese
+    footercontent: 欢迎来到我的个人网站！
+    params:
+      info: 'iOS 开发者、DevOps、博主、游戏玩家'
+    menu:
+      main:
+        - name: 首页
+          url: /
+          weight: 1
+        - name: 文章
+          weight: 2
+          url: /posts/
+        - name: 订阅
+          weight: 3
+          url: /zh/index.xml
+        - name: TIL
+          weight: 4
+          url: https://til.yusuke.cloud
+        - name: nostr
+          weight: 5
+          url: https://nostr.yusuke.cloud/junkpiano@yusuke.cloud
+  de:
+    LanguageName: ':de:'
+    contentDir: content/german
+    footercontent: Willkommen auf meiner persönlichen Website!
+    params:
+      info: 'iOS-Entwickler, DevOps, Blogger und Gamer'
+    menu:
+      main:
+        - name: Startseite
+          url: /
+          weight: 1
+        - name: Beiträge
+          weight: 2
+          url: /posts/
+        - name: RSS
+          weight: 3
+          url: /de/index.xml
+        - name: TIL
+          weight: 4
+          url: https://til.yusuke.cloud
+        - name: nostr
+          weight: 5
+          url: https://nostr.yusuke.cloud/junkpiano@yusuke.cloud


### PR DESCRIPTION
## Summary

Adds `zh` (`content/chinese`) and `de` (`content/german`) to `config.yml` with translated menus, footer text, and author bio, mirroring the existing `ja` setup.

## Companion PR

The translated content lives in junkpiano/yusuke.cloud-content#4. Merge order:

1. Merge the content PR
2. Merge this PR and bump the `content` submodule pointer to the new master

Verified locally with Hugo 0.147 (translations + this config): clean build, 118–120 pages per language, correct `alternate hreflang` links between all four versions of each post.